### PR TITLE
Replace `df` with `mount` on UNIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Get the system disk of the computer (e.g. `C:` or `/dev/sda`)
 
-For Windows this module uses the [`%SystemDrive%`](http://environmentvariables.org/SystemDrive) environment variable and the [`df`](https://en.wikipedia.org/wiki/Df_(Unix)) command for macOS and Linux.
+For Windows this module uses the [`%SystemDrive%`](http://environmentvariables.org/SystemDrive) environment variable and the [`mount`](https://en.wikipedia.org/wiki/Mount_(Unix)) command for macOS and Linux.
 
 ## Installation
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
 Get the system disk of the computer (e.g. `C:` or `/dev/sda`)
 
-For Windows this module uses the [`%SystemDrive%`](http://environmentvariables.org/SystemDrive) environment variable and the [`df`](https://en.wikipedia.org/wiki/Df_(Unix)) command for macOS and Linux.
+For Windows this module uses the [`%SystemDrive%`](http://environmentvariables.org/SystemDrive) environment variable and the [`mount`](https://en.wikipedia.org/wiki/Mount_(Unix)) command for macOS and Linux.
 
 @example
 ```

--- a/index.js
+++ b/index.js
@@ -2,15 +2,11 @@ import {promisify} from 'node:util';
 import {exec} from 'node:child_process';
 
 const execAsync = promisify(exec);
-const commands = {
-	win32: 'echo %SystemDrive%',
-	darwin: 'df -l | awk \'$9 == "/"\''
-};
 
 export default async function systemDisk() {
-	const command = process.platform in commands
-		? commands[process.platform]
-		: 'df -l | awk \'$6 == "/"\'';
+	const command = process.platform === 'win32'
+		? 'echo %SystemDrive%'
+		: 'mount | awk \'$3 == "/"\'';
 	const {error, stdout, stderr} = await execAsync(command);
 
 	if (error || stderr) {
@@ -21,9 +17,5 @@ export default async function systemDisk() {
 		return stdout.split('\r\n')[0];
 	}
 
-	if (process.platform === 'darwin') {
-		return stdout.split('  ')[0];
-	}
-
-	return stdout.split('   ')[0];
+	return stdout.split('\n')[0];
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const execAsync = promisify(exec);
 export default async function systemDisk() {
 	const command = process.platform === 'win32'
 		? 'echo %SystemDrive%'
-		: 'mount | awk \'$3 == "/"\'';
+		: 'mount | awk \'$3 == "/" {print $1}\'';
 	const {error, stdout, stderr} = await execAsync(command);
 
 	if (error || stderr) {


### PR DESCRIPTION
Partly because GitHub Actions fails with `df: getattrlist failed: Input/output error` on macOS 🤷‍♂️